### PR TITLE
Upgrade to Debian 12

### DIFF
--- a/vps.tf
+++ b/vps.tf
@@ -1,7 +1,7 @@
 locals {
   //Map host name code to OS image
   images = {
-    "dn" = "debian-11-x64",
+    "dn" = "debian-12-x64",
     "cs" = "centos-stream-9-x64",
     "rl" = "rockylinux-9-x64",
     "al" = "almalinux-9-x64",


### PR DESCRIPTION
We must use Debian 12 for new installations after https://github.com/NethServer/ns8-core/pull/415 is merged.