### PR TITLE
feat: run tests on Debian 13 (Trixie)

### DIFF
--- a/vps.tf
+++ b/vps.tf
@@ -1,7 +1,7 @@
 locals {
   //Map host name code to OS image
   images = {
-    "dn" = "debian-12-x64",
+    "dn" = "debian-13-x64",
     "cs" = "centos-stream-9-x64",
     "rl" = "rockylinux-9-x64",
     "al" = "almalinux-9-x64",


### PR DESCRIPTION
When core supports Debian 13, we can run automated tests on it. See https://github.com/NethServer/ns8-core/pull/1038

Refs NethServer/dev#7608